### PR TITLE
Add a way to create compile_commands.json, lifted from godot-cpp.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@
 gdextension_interface.h
 extension_api.json
 
+# Build tools
 /docs/*build/
-
-
+compile_commands.json

--- a/SConstruct
+++ b/SConstruct
@@ -121,6 +121,23 @@ opts.Add(
 )
 
 
+opts.Add(
+	BoolVariable(
+		key="compiledb",
+		help="Generate compilation DB (`compile_commands.json`) for external tools",
+		default=env.get("compiledb", False),
+	)
+)
+
+opts.Add(
+	PathVariable(
+		key="compiledb_file",
+		help="Path to a custom `compile_commands.json` file",
+		default=env.get("compiledb_file", "compile_commands.json"),
+		validator=build_utils.validate_parent_dir,
+	)
+)
+
 # for now there's no distinction between build targets, so always use template_release
 env['target'] = 'template_release'
 
@@ -266,6 +283,9 @@ env.Alias("archive_importer_r_string", [
 		],
 	)
 ])
+
+env.Tool("compilation_db")
+env.Alias("compiledb", env.CompilationDatabase(build_utils.normalize_path(env["compiledb_file"], env)))
 
 if not env.get('skip_module_embed', False):
 	# pkg_files = Install('src', files)


### PR DESCRIPTION
compile_commands.json can be used for IDE support, for example CLion, like:
```bash
scons compiledb=yes compile_commands.json
```

The logic and code in particular were lifted from [godot-cpp](https://github.com/godotengine/godot-cpp/blob/a98d41f62bdb8b7aa903e8e37c1faa48fe8fdae8/tools/godotcpp.py#L283).
Feel free to move the additions around in your SConstruct. I didn't feel comfortable with any spot in particular so I just placed them somewhere.