### PR TITLE
Fix the builds on macOS (universal).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,22 @@ on:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - platform: linux
+            arch: x86_64
+            os: ubuntu-latest
+          - platform: windows
+            arch: x86_64
+            os: windows-latest
+          - platform: macos
+            arch: x86_64
+            os: macos-latest
+          - platform: macos
+            arch: arm64
+            os: macos-latest
 
     steps:
       - name: Checkout repository
@@ -39,31 +50,31 @@ jobs:
       - name: Build extension (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          scons platform=linux arch=x86_64 single_source=true
+          scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} single_source=true
 
       - name: Build extension (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          scons platform=windows arch=x86_64 single_source=true
+          scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} single_source=true
 
       - name: Build extension (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          scons platform=macos arch=universal single_source=true
+          scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} single_source=true
 
       - name: Create archive (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           cd bin/
-          zip -q -r ../godot-python-linux-x86_64.zip *
+          zip -q -r ../godot-python-${{ matrix.platform }}-${{ matrix.arch }}.zip *
           cd ../
 
       - name: Upload artifacts (Linux)
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: godot-python-linux-x86_64
+          name: godot-python-${{ matrix.platform }}-${{ matrix.arch }}
           path: godot-python*.zip
           retention-days: 30
 
@@ -71,7 +82,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: godot-python-windows-x86_64
+          name: godot-python-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
             bin/**/*
             !bin/**/*.lib
@@ -82,11 +93,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: godot-python-macos-universal
-          path: |
-            bin/**/*
-            !bin/**/*.lib
-            !bin/**/*.exp
+          name: godot-python-${{ matrix.platform }}-${{ matrix.arch }}
+          path: bin/**/*
           retention-days: 30
 
       - name: Release artifact

--- a/SConstruct
+++ b/SConstruct
@@ -199,6 +199,11 @@ python_sources = set()
 
 sources.update(pathlib.Path('src').glob('**/*.cpp'))
 
+if env['platform'] == 'macos':
+	# For Objective-C++ files
+	env.Append(CCFLAGS = ['-ObjC++'])
+	sources.update(pathlib.Path('src').glob('**/*.mm'))
+
 for ext in ('py', 'pyc', 'json', 'svg', 'md'):
 	python_sources.update(pathlib.Path('lib').glob(f'**/*.{ext}'))
 
@@ -340,7 +345,6 @@ strip = env.get('strip', False)
 if not env.get('is_msvc'):
 	env.Append(CCFLAGS = ['-fvisibility=hidden', *['-flto'] * with_lto]) # XXX
 	env.Append(LINKFLAGS = ['-fvisibility=hidden', *['-flto'] * with_lto, *['-s'] * strip]) # XXX
-
 else:
 	env.Append(LIBS = ['Shell32.lib', ])
 
@@ -348,6 +352,11 @@ else:
 if env['platform'] == 'windows':
 	# linker has trouble if the table is too large
 	env.Append(CPPDEFINES = ['CLASS_VIRTUAL_CALL_TABLE_SIZE=512'])
+elif env['platform'] == 'macos':
+	# Need to set the rpath for relative loading of libpython to succeed.
+	# This doesn't work for some reason
+	# env.Replace(RPATH=['@loader_path'])
+	env.Append(LINKFLAGS=['-Wl,-rpath,@loader_path'])
 
 
 env.Prepend(CPPPATH=['src', os.fspath(generated_path), 'extern/pybind11/include'])

--- a/src/util/macos.h
+++ b/src/util/macos.h
@@ -1,0 +1,15 @@
+#ifndef MACOS_H
+#define MACOS_H
+
+#include <vector>
+#include <string>
+#include <filesystem>
+
+namespace macos {
+
+// get the full argv passed to the main process
+std::vector<std::string> get_argv();
+
+}
+
+#endif //MACOS_H

--- a/src/util/macos.mm
+++ b/src/util/macos.mm
@@ -1,0 +1,13 @@
+#include "util/macos.h"
+
+#import <Foundation/Foundation.h>
+
+
+std::vector<std::string> macos::get_argv() {
+	std::vector<std::string> argv;
+	NSArray *argv_objc = [[NSProcessInfo processInfo] arguments];
+	for (NSString *arg in argv_objc) {
+		argv.push_back([arg UTF8String]);
+	}
+	return argv;
+}

--- a/test/python.gdextension
+++ b/test/python.gdextension
@@ -5,7 +5,8 @@ entry_symbol = "python_extension_init"
 
 [libraries]
 
-macos = "res://bin/macos/libgodot-python.macos.framework"
+macos.x86_64 = "res://bin/macos-x86_64/libgodot-python.macos.x86_64.dylib"
+macos.arm64 = "res://bin/macos-arm64/libgodot-python.macos.arm64.dylib"
 
 windows.x86_32 = "res://bin/windows-x86_32/libgodot-python.windows.x86_32.dll"
 windows.x86_64 = "res://bin/windows-x86_64/libgodot-python.windows.x86_64.dll"
@@ -16,4 +17,3 @@ linux.rv64 = "res://bin/linux-rv64/libgodot-python.linux.rv64.so"
 
 android.x86_64 = "res://bin/android-x86_64/libgodot-python.android.x86_64.so"
 android.arm64 = "res://bin/android-arm64/libgodot-python.android.arm64.so"
-

--- a/tools/build/build_utils.py
+++ b/tools/build/build_utils.py
@@ -124,9 +124,9 @@ def process_arch(env):
 		# No architecture specified. Default to arm64 if building for Android,
 		# universal if building for macOS or iOS, wasm32 if building for web,
 		# otherwise default to the host architecture.
-		if env["platform"] in ["macos", "ios"]:
-			env["arch"] = "universal"
-		elif env["platform"] == "android":
+		# if env["platform"] in ["macos", "ios"]:
+		# 	env["arch"] = "universal"
+		if env["platform"] == "android":
 			env["arch"] = "arm64"
 		elif env["platform"] == "web":
 			env["arch"] = "wasm32"

--- a/tools/build/python_config.py
+++ b/tools/build/python_config.py
@@ -111,7 +111,7 @@ def get_python_config_vars(env) -> types.SimpleNamespace:
 
 	config_vars.link_libs = _stable_unique([
 			*itertools.chain(*(
-				(v.removeprefix('-l') for v in value.split())
+				(v.removeprefix('-l') for v in value.split() if v.startswith('-l'))
 				for name in ('LIBS', 'SYSLIBS')
 				if (value := sysconfig_vars.get(name))
 			)),


### PR DESCRIPTION
A few comments:

### `std::quick_exit`
`std::quick_exit` is not supported on macOS. For the replacement call I referenced this change:
https://github.com/wesnoth/wesnoth/commit/6ce218f7a2137546dad90bbcb77d160089aadb7c#diff-fc3beea58bc7268f70c24a27ee7f556f6440c92ebb72d7db4ff321b82cec4df4R182

(Oh, i didn't even realize it was from wesnoth. Nice!)

### libs
The line `(v.removeprefix('-l') for v in value.split())` failed for the following error:
```
❯ scons
scons: Reading SConscript files ...
Auto-detected 16 CPU cores available for build parallelism. Using 15 cores by default. You can override it with the -j argument.
Building for architecture universal on platform macos
scons: done reading SConscript files.
scons: Building targets ...
clang++ -o bin/macos-universal/libgodot-python.macos.universal.dylib -arch x86_64 -arch arm64 -framework Cocoa -Wl,-undefined,dynamic_lookup -fvisibility=hidden -Wl,-S -Wl,-x -Wl,-dead_strip -Wl,-S -Wl,-x -Wl,-dead_strip -fvisibility=hidden -ldl -framework CoreFoundation -shared src/extension/.extension.os src/module/.class_creation_info.os src/module/.class_method_info.os src/module/.module.os src/module/.property_info.os src/module/.property_list.os src/module/.script_instance_info.os src/util/.exceptions.os src/util/.python_utils.os src/util/.system.os src/variant/.callable.os src/variant/.object.os src/variant/.string.os src/variant/.string_name.os src/variant/.variant.os src/.generated/.godot_module_archive.os -Lsrc/.generated/python/macos-universal/python/lib -ldl -l-framework -lCoreFoundation -lpython3.12
ld: warning: ignoring duplicate libraries: '-ldl'
ld: library '-framework' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [bin/macos-universal/libgodot-python.macos.universal.dylib] Error 1
scons: building terminated because of errors.
```

I printed `print(config_vars.link_libs)` to get the following result:
```
['dl', '-framework', 'CoreFoundation', 'python3.12']
```

CoreFoundation is technically a library, but it doesn't compile with it:
```
clang++ -o bin/macos-universal/libgodot-python.macos.universal.dylib -arch x86_64 -arch arm64 -framework Cocoa -Wl,-undefined,dynamic_lookup -fvisibility=hidden -Wl,-S -Wl,-x -Wl,-dead_strip -Wl,-S -Wl,-x -Wl,-dead_strip -fvisibility=hidden -ldl -framework CoreFoundation -shared src/extension/.extension.os src/module/.class_creation_info.os src/module/.class_method_info.os src/module/.module.os src/module/.property_info.os src/module/.property_list.os src/module/.script_instance_info.os src/util/.exceptions.os src/util/.python_utils.os src/util/.system.os src/variant/.callable.os src/variant/.object.os src/variant/.string.os src/variant/.string_name.os src/variant/.variant.os src/.generated/.godot_module_archive.os -Lsrc/.generated/python/macos-universal/python/lib -lCoreFoundation
ld: library 'CoreFoundation' not found
```

Since it compiles fine without it, I conclude none of my items are libraries. I'm sure there's a reason the line is there, so I opted to just include the libraries if they actually do start with `-l` (even if there aren't any that do on my end).

### strip -s
`strip -s` is not supported as that in macOS. But to strip dylibs, `-x` is needed. I opted to just separate the 2 lines, it's likely more differences may emerge in the future.

### dylib vs framework

On macOS, [both dylibs and frameworks are supported](https://github.com/godotengine/godot-cpp-template/pull/55#discussion_r1786005742). On iOS, only `.framework` is supported. `.framework` and `.dylib` have the same binary but slightly different directory structures. The reason godot-cpp defaults to `.framework` is for consistency to iOS, as well as for signing the binary later. This is not important for now since the python extension supports neither iOS nor signing currently. Besides, godot's loading of `.framework` [remains spotty](https://github.com/godotengine/godot/issues/96403), and I don't want to fiddle with SConstruct too much for now. We can switch over later `.framework` later when it becomes relevant.

### More work
The current build still has 3 warnings:
```
ld: warning: ignoring duplicate libraries: '-ldl'
ld: warning: ignoring duplicate libraries: '-ldl'
ld: warning: ignoring file '/Users/lukas/dev/godot/godot-python-extension/src/.generated/python/macos-universal/python/lib/libpython3.12.dylib': found architecture 'x86_64', required architecture 'arm64'
```

At least the final warning is probably relevant for arm macs, but we can address it later. For now, `libgodot-python.macos.universal.dylib` is built, and that's better than before.

I have not yet tested the library in action.

Edit: I have now, it works.