### PR TITLE
Simplify apply_type_list to not use a lambda to fix windows builds. Fixes #28.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout repository

--- a/src/variant/traits.h
+++ b/src/variant/traits.h
@@ -105,11 +105,15 @@ using concat_type_lists = typename _concat_type_lists<Ls...>::type;
 
 
 template<template<typename...> typename Template, typename TypeList>
-using apply_type_list = decltype([]<typename... Ts>(type_list<Ts...>)
-	-> Template<Ts...>
-{
-	return std::declval<Template<Ts...>>();
-}(TypeList{}));
+struct _apply_type_list;
+
+template<template<typename...> typename Template, typename... Ts>
+struct _apply_type_list<Template, type_list<Ts...>> {
+	using type = Template<Ts...>;
+};
+
+template<template<typename...> typename Template, typename TypeList>
+using apply_type_list = typename _apply_type_list<Template, TypeList>::type;
 
 
 template<typename T, typename... Ts>


### PR DESCRIPTION
Runner will still fail because of macOS (#26), but Windows runner succeeds now.