### PR TITLE
Add a docs entry for documenting the current state of platforms support.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ This project released under the MIT license, see the [license.md](https://github
 :maxdepth: 3
 
 usage/installation
+usage/platforms
 usage/type-conversions
 reference/index
 ```

--- a/docs/usage/platforms.md
+++ b/docs/usage/platforms.md
@@ -1,0 +1,23 @@
+# Platforms
+
+The following is Godot-Python's current state of support for various platforms and architectures:
+
+|                  | Local Installation    | Export    | PyPi Packages / Pip |
+|------------------|-----------------------|-----------|---------------------|
+| Windows (x86_32) | Planned.              | Untested. | Planned.            |
+| Windows (x86_64) | Supported.            | Untested. | Planned.            |
+| Windows (arm32)  | Planned.              | Planned.  | Planned.            |
+| Windows (arm64)  | Planned.              | Planned.  | Planned.            |
+| Linux (x86_32)   | Planned.              | Untested. | Planned.            |
+| Linux (x86_64)   | Supported.            | Untested. | Planned.            |
+| Linux (arm32)    | Planned.              | Planned.  | Planned.            |
+| Linux (arm64)    | Planned.              | Planned.  | Planned.            |
+| Android (x86_32) | Planned.              | Planned.  | Planned.            |
+| Android (x86_64) | Planned.              | Planned.  | Planned.            |
+| Android (arm32)  | Planned.              | Planned.  | Planned.            |
+| Android (arm64)  | Planned.              | Planned.  | Planned.            |
+| macOS (x86_64)   | Supported.            | Untested. | Planned.            |
+| macOS (arm64)    | Supported (untested). | Untested. | Planned.            |
+| iOS (x86_64)     | Planned.              | Planned.  | Planned.            |
+| iOS (arm64)      | Planned.              | Planned.  | Planned.            |
+| Web (wasm32)     | Planned.              | Planned.  | Planned.            |


### PR DESCRIPTION
Closes #22.