### PR TITLE
Disable fail-fast for the github runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: linux


### PR DESCRIPTION
This will prevent one failing runner from stopping the others going through.

This can be very helpful in debugging if a change breaks anything.