### PR TITLE
Use setup-python@v5.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           submodules: true
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
This prevents the Node.js warning (for setup-python@v4):

![SCR-20241028-qgjs](https://github.com/user-attachments/assets/33564ece-f0e3-4b87-ba44-a557fbf62521)
